### PR TITLE
Gen server

### DIFF
--- a/lib/warehouse_simulator/checker.ex
+++ b/lib/warehouse_simulator/checker.ex
@@ -22,7 +22,7 @@ defmodule WarehouseSimulator.Checker do
   def get_and_put_next_line_member(checker, next_in_line, module) do
     Agent.get_and_update(checker, fn state ->
       LineMember.get_and_put_next_line_member(state[:line_member], next_in_line, module)
-      |> merge_line_member_state(state)
+      |> LineMember.merge_line_member_state(state)
     end)
   end
 
@@ -37,7 +37,7 @@ defmodule WarehouseSimulator.Checker do
           current_contents,
           check_duration(state[:parameters], pick_ticket, current_contents)
         )
-        |> merge_line_member_state(state)
+        |> LineMember.merge_line_member_state(state)
       end,
       :infinity
     )
@@ -62,9 +62,5 @@ defmodule WarehouseSimulator.Checker do
         item_count * parameters.seconds_per_item +
         pick_count * parameters.seconds_per_quantity
     end
-  end
-
-  defp merge_line_member_state({value, member_state}, state) do
-    {value, %{state | line_member: member_state}}
   end
 end

--- a/lib/warehouse_simulator/line_member.ex
+++ b/lib/warehouse_simulator/line_member.ex
@@ -73,6 +73,14 @@ defmodule WarehouseSimulator.LineMember do
      %{state | next_in_line: next_in_line, next_module: module, blocked_until: 0.0}}
   end
 
+  def merge_line_member_state({value, member_state}, state, key \\ :line_member) do
+    {value, Map.put(state, key, member_state)}
+  end
+
+  def line_member_reply({value, member_state}, state, key \\ :line_member) do
+    {:reply, value, Map.put(state, key, member_state)}
+  end
+
   defp pass_down_line(state, pick_ticket, contents) do
     next = state.next_in_line
 

--- a/lib/warehouse_simulator/picker.ex
+++ b/lib/warehouse_simulator/picker.ex
@@ -48,12 +48,12 @@ defmodule WarehouseSimulator.Picker do
       contents,
       duration
     )
-    |> reply(state)
+    |> LineMember.line_member_reply(state)
   end
 
   def handle_call({:get_and_put_next_line_member, next_in_line, module}, _from, state) do
     LineMember.get_and_put_next_line_member(state[:line_member], next_in_line, module)
-    |> reply(state)
+    |> LineMember.line_member_reply(state)
   end
 
   def handle_call({:elapsed_time}, _from, state) do
@@ -75,9 +75,5 @@ defmodule WarehouseSimulator.Picker do
         pick_count * parameters.seconds_per_quantity
 
     {duration, Map.merge(current_contents, picks)}
-  end
-
-  defp reply({value, member_state}, state) do
-    {:reply, value, %{state | line_member: member_state}}
   end
 end

--- a/test/warehouse_simulator/line_member_test.exs
+++ b/test/warehouse_simulator/line_member_test.exs
@@ -24,7 +24,7 @@ defmodule WarehouseSimulator.LineMemberTest do
             Map.merge(current_contents, %{"A" => 1}),
             1.0
           )
-          |> merge_line_member_state(state)
+          |> LineMember.merge_line_member_state(state)
         end
       )
     end
@@ -32,7 +32,7 @@ defmodule WarehouseSimulator.LineMemberTest do
     def get_and_put_next_line_member(checker, next_in_line, module) do
       Agent.get_and_update(checker, fn state ->
         LineMember.get_and_put_next_line_member(state[:line_member], next_in_line, module)
-        |> merge_line_member_state(state)
+        |> LineMember.merge_line_member_state(state)
       end)
     end
 
@@ -42,10 +42,6 @@ defmodule WarehouseSimulator.LineMemberTest do
 
     def idle_time(checker) do
       Agent.get(checker, & &1[:line_member].idle_duration)
-    end
-
-    defp merge_line_member_state({value, member_state}, state) do
-      {value, %{state | line_member: member_state}}
     end
   end
 
@@ -74,7 +70,7 @@ defmodule WarehouseSimulator.LineMemberTest do
     def get_and_put_next_line_member(checker, next_in_line, module) do
       Agent.get_and_update(checker, fn state ->
         LineMember.get_and_put_next_line_member(state[:line_member], next_in_line, module)
-        |> merge_line_member_state(state)
+        |> LineMember.merge_line_member_state(state)
       end)
     end
 
@@ -84,10 +80,6 @@ defmodule WarehouseSimulator.LineMemberTest do
 
     def idle_time(checker) do
       Agent.get(checker, & &1[:line_member].idle_duration)
-    end
-
-    defp merge_line_member_state({value, member_state}, state) do
-      {value, %{state | line_member: member_state}}
     end
 
     def state(member) do


### PR DESCRIPTION
This PR changes `LineMember` from assuming an `Agent` implementation to allowing a `GenServer` one.  Since our processing is a sequential pipeline and we kind of need the backward information flow to know when members are "blocked" from passing work forward, we still use `call` and not `cast`.  